### PR TITLE
Improve mobile layout for services and experiences

### DIFF
--- a/components/sectionStyles.ts
+++ b/components/sectionStyles.ts
@@ -1,0 +1,8 @@
+export const sectionTitleClasses =
+  'text-3xl sm:text-4xl font-black tracking-tight text-center text-white';
+
+export const sectionTitleGradientClasses =
+  `${sectionTitleClasses} bg-clip-text text-transparent bg-gradient-to-r from-[#10b981] via-white to-[#6366f1]`;
+
+export const cardBaseClasses =
+  'rounded-3xl border border-white/10 bg-gradient-to-b from-[#1f2429] via-[#1b2024] to-[#15181c] shadow-[0_35px_85px_-45px_rgba(2,6,23,1)] transition-all duration-300 hover:-translate-y-1 hover:border-[#10b981] hover:shadow-[0_45px_110px_-40px_rgba(16,185,129,0.55)] focus-within:ring-2 focus-within:ring-[#10b981]/60 focus-within:ring-offset-2 focus-within:ring-offset-[#0f1115]';

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -10,18 +10,28 @@ import {
   Theater,
   Compass
 } from 'lucide-react';
+import { cardBaseClasses, sectionTitleGradientClasses } from '../sectionStyles';
 
 
 
 export default function About() {
   return (
     <section id="about" className="py-24 px-4 w-full bg-transparent scroll-mt-24" aria-labelledby="about-title">
+      <div className="max-w-5xl mx-auto text-center mb-12">
+        <h2 id="about-title" className={sectionTitleGradientClasses}>
+          À propos & passions
+        </h2>
+        <p className="mt-3 text-base text-gray-300">
+          Quelques repères pour mieux me connaître en dehors d’un CV traditionnel.
+        </p>
+      </div>
       <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 items-stretch">
         {/* À propos */}
-        <article className="bg-[#22272a] rounded-2xl shadow-xl p-10 border border-white/10 h-full flex flex-col" aria-labelledby="about-title">
-          <h2 id="about-title" className="text-3xl font-extrabold mb-6 text-[#10b981] flex items-center gap-3">
-            <Briefcase className="w-8 h-8" aria-hidden="true" /> À propos
-          </h2>
+        <article className={`${cardBaseClasses} h-full flex flex-col p-10 text-left`} aria-labelledby="about-details">
+          <h3 id="about-details" className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <Briefcase className="w-7 h-7 text-[#10b981]" aria-hidden="true" />
+            À propos
+          </h3>
           <ul className="space-y-4 text-gray-100 text-lg">
             <li className="flex items-center gap-3">
               <MapPin className="text-[#6366f1] w-6 h-6" aria-hidden="true" />
@@ -46,10 +56,11 @@ export default function About() {
           </ul>
         </article>
         {/* Passions */}
-        <article className="bg-[#22272a] rounded-2xl shadow-xl p-10 border border-white/10 h-full flex flex-col" aria-labelledby="passions-title">
-          <h2 id="passions-title" className="text-3xl font-extrabold mb-6 text-[#10b981] flex items-center gap-3">
-            <Soup className="w-8 h-8" aria-hidden="true" /> Passions
-          </h2>
+        <article className={`${cardBaseClasses} h-full flex flex-col p-10 text-left`} aria-labelledby="passions-title">
+          <h3 id="passions-title" className="text-2xl font-bold text-white mb-6 flex items-center gap-3">
+            <Soup className="w-7 h-7 text-[#10b981]" aria-hidden="true" />
+            Passions
+          </h3>
           <ul className="flex flex-wrap gap-3">
             <li>
               <span className="flex items-center gap-2 bg-[#134e4a] text-[#f0fdf4] rounded-lg px-4 py-2 font-semibold text-lg">

--- a/components/sections/BlogPreview.tsx
+++ b/components/sections/BlogPreview.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Post } from "../../types";
 import { formatDateFR } from "../../lib/formatDate";
 import TagLabel from "../TagLabel";
+import { cardBaseClasses, sectionTitleGradientClasses } from "../sectionStyles";
 
 type BlogPreviewProps = {
   posts: Post[];
@@ -15,7 +16,7 @@ export default function BlogPreview({ posts = [] }: BlogPreviewProps) {
       <div className="max-w-5xl mx-auto">
         <h2
           id="blog-title"
-          className="text-3xl sm:text-4xl font-black mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-[#10b981] via-white to-[#6366f1]"
+          className={`${sectionTitleGradientClasses} mb-12`}
         >
           Derniers articles
         </h2>
@@ -24,12 +25,12 @@ export default function BlogPreview({ posts = [] }: BlogPreviewProps) {
             latestPosts.map((post) => (
               <li key={post.slug} className="h-full">
                 <article
-                  className="bg-[#23272a] rounded-2xl shadow-lg border border-white/10 transition hover:scale-[1.02] hover:shadow-2xl hover:border-[#10b981] focus-within:outline-none h-full flex flex-col"
+                  className={`${cardBaseClasses} h-full flex flex-col`}
                   aria-labelledby={`post-${post.slug}`}
                 >
                   <Link
                     href={`/blog/${post.slug}`}
-                    className="flex flex-col flex-1 p-6 gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#23272a]"
+                    className="flex flex-col flex-1 p-6 gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1115]"
                     aria-labelledby={`post-${post.slug}`}
                   >
                     {post.cover && (

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -1,4 +1,5 @@
 import { Mail, Linkedin } from "lucide-react";
+import { cardBaseClasses, sectionTitleGradientClasses } from "../sectionStyles";
 
 export default function Contact() {
   return (
@@ -7,30 +8,30 @@ export default function Contact() {
       className="py-20 w-full bg-transparent flex flex-col items-center scroll-mt-24"
       aria-labelledby="contact-title"
     >
-      <div className="max-w-md w-full bg-[#23272a] rounded-2xl shadow-xl p-10 border border-white/10 mx-auto">
-        <h2 id="contact-title" className="text-3xl font-extrabold mb-6 text-center text-white tracking-tight">
+      <div className={`${cardBaseClasses} max-w-md w-full mx-auto p-10`}>
+        <h2 id="contact-title" className={`${sectionTitleGradientClasses} mb-6`}>
           Contact
         </h2>
         <p className="mb-6 text-gray-200 text-center">
           Envie d’échanger sur un projet ? Discutons !
         </p>
         <address className="not-italic space-y-4 mb-8 text-center">
-          <div className="flex items-center gap-2 bg-[#181b1f] rounded-lg px-4 py-3 justify-center">
+          <div className="flex items-center gap-2 bg-[#111418] rounded-lg px-4 py-3 justify-center">
             <Mail className="w-5 h-5 text-[#10b981]" aria-hidden="true" />
             <a
               href="mailto:maxime@herbaut.me"
-              className="text-[#10b981] font-semibold hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#181b1f] rounded"
+              className="text-[#10b981] font-semibold hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111418] rounded"
             >
               maxime@herbaut.me
             </a>
           </div>
-          <div className="flex items-center gap-2 bg-[#181b1f] rounded-lg px-4 py-3 justify-center">
+          <div className="flex items-center gap-2 bg-[#111418] rounded-lg px-4 py-3 justify-center">
             <Linkedin className="w-5 h-5 text-[#10b981]" aria-hidden="true" />
             <a
               href="https://www.linkedin.com/in/maximeherbaut"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[#10b981] font-semibold hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#181b1f] rounded"
+              className="text-[#10b981] font-semibold hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111418] rounded"
             >
               maximeherbaut
               <span className="sr-only"> (ouvre dans un nouvel onglet)</span>
@@ -39,7 +40,7 @@ export default function Contact() {
         </address>
         <a
           href="https://calendly.com/maximeherbaut/30min"
-          className="block text-center bg-[#10b981] hover:bg-[#11936c] text-white font-bold rounded-lg py-3 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-[#23272a]"
+          className="block text-center bg-gradient-to-r from-[#10b981] to-[#6366f1] hover:from-[#0d966c] hover:to-[#4f46e5] text-white font-bold rounded-xl py-3 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-[#0f1115]"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/components/sections/Experiences.tsx
+++ b/components/sections/Experiences.tsx
@@ -1,12 +1,13 @@
 import { experiencesData } from '../../data/experiences';
 import { formatDescription } from '../../lib/experience';
+import { cardBaseClasses, sectionTitleGradientClasses } from '../sectionStyles';
 
 export default function Experiences() {
   return (
     <section id="experiences" className="py-24 scroll-mt-24" aria-labelledby="experiences-title">
       <h2
         id="experiences-title"
-        className="mb-12 text-center text-3xl font-extrabold tracking-tight text-white sm:text-4xl"
+        className={`${sectionTitleGradientClasses} mb-12`}
       >
         Expériences
       </h2>
@@ -19,7 +20,7 @@ export default function Experiences() {
             {experiencesData.map((exp, idx) => (
               <article
                 key={`${exp.company}-${idx}`}
-                className="relative rounded-3xl border border-white/5 bg-[#1d2125] p-6 pl-12 shadow-[0_15px_40px_-30px_rgba(16,185,129,0.8)] transition hover:border-[#10b981]/40 hover:shadow-[0_25px_50px_-30px_rgba(16,185,129,1)] sm:p-8 sm:pl-20"
+                className={`${cardBaseClasses} relative p-6 pl-12 sm:p-8 sm:pl-20`}
                 aria-labelledby={`experience-${idx}`}
               >
                 <span

--- a/components/sections/Experiences.tsx
+++ b/components/sections/Experiences.tsx
@@ -5,11 +5,15 @@ import { formatDescription } from '../../lib/experience';
 
 export default function Experiences() {
   const scrollRef = useRef<HTMLDivElement>(null);
+
   const scrollRight = (idx: number) => {
     if (!scrollRef.current) return;
+
     const cards = scrollRef.current.querySelectorAll('.exp-card');
-    const card = cards[idx + 1] as HTMLElement;
-    if (card) card.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'nearest' });
+    const card = cards[idx + 1] as HTMLElement | undefined;
+    if (card) {
+      card.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'nearest' });
+    }
   };
 
   return (
@@ -17,10 +21,11 @@ export default function Experiences() {
       <h2 id="experiences-title" className="text-3xl font-extrabold mb-10 text-center text-white tracking-tight">
         Expériences
       </h2>
-      <div className="relative max-w-[100vw] px-4" style={{ overflow: 'hidden' }}>
+
+      <div className="relative max-w-[100vw] px-4">
         <div
           ref={scrollRef}
-          className="flex items-stretch gap-4 md:gap-8 pl-4 pr-4 sm:pl-8 sm:pr-8 overflow-x-auto snap-x snap-mandatory scrollbar-hide"
+          className="flex items-stretch gap-4 md:gap-8 pl-4 pr-12 sm:pl-8 sm:pr-16 overflow-x-auto snap-x snap-mandatory scrollbar-hide"
           style={{ WebkitOverflowScrolling: 'touch', scrollBehavior: 'smooth' }}
           tabIndex={0}
           role="list"
@@ -29,22 +34,20 @@ export default function Experiences() {
           {experiencesData.map((exp, idx) => (
             <div key={exp.company + idx} className="flex items-center" role="listitem">
               <article
-                className={`exp-card relative pt-6 min-w-[280px] md:min-w-[340px] max-w-sm bg-[#23272a] rounded-2xl shadow-xl p-8 md:p-10 border border-white/10 flex-shrink-0 flex flex-col h-full snap-start transition-transform duration-300 hover:scale-[1.02] hover:border-[#10b981]`}
+                className="exp-card relative flex h-full min-w-[280px] max-w-sm flex-shrink-0 flex-col rounded-2xl border border-white/10 bg-[#23272a] p-8 pt-6 shadow-xl transition-transform duration-300 hover:scale-[1.02] hover:border-[#10b981] md:min-w-[340px] md:p-10"
                 aria-labelledby={`experience-${idx}`}
               >
-                {/* 🟢 Badge date dans le coin */}
-                <div className="absolute top-0 right-0 bg-[#10b981]/20 text-[#10b981] text-xs font-semibold px-3 py-1 rounded-bl-2xl rounded-tr-2xl border border-[#10b981]/30">
+                <div className="absolute right-0 top-0 rounded-bl-2xl rounded-tr-2xl border border-[#10b981]/30 bg-[#10b981]/20 px-3 py-1 text-xs font-semibold text-[#10b981]">
                   {exp.date}
                 </div>
 
                 <div className="space-y-4">
-                  {/* (on enlève l’ancien <Tag> placé en haut du contenu) */}
                   <header id={`experience-${idx}`} className="space-y-1">
-                    <p className="text-2xl font-extrabold mb-1 text-white">{exp.company}</p>
-                    <p className="text-[12px] tracking-[0.12em] uppercase text-gray-300">{exp.role}</p>
+                    <p className="text-2xl font-extrabold text-white">{exp.company}</p>
+                    <p className="text-[12px] uppercase tracking-[0.12em] text-gray-300">{exp.role}</p>
                   </header>
                   <p
-                    className="text-sm text-gray-200 leading-relaxed"
+                    className="text-sm leading-relaxed text-gray-200"
                     dangerouslySetInnerHTML={{ __html: formatDescription(exp.description) }}
                   />
                 </div>
@@ -53,11 +56,11 @@ export default function Experiences() {
               {idx < experiencesData.length - 1 && (
                 <button
                   type="button"
-                  className="ml-2 flex h-12 w-12 items-center justify-center rounded-full border border-[#10b981]/40 bg-[#10b981]/15 text-[#10b981] shadow-lg shadow-black/30 backdrop-blur-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#181b1f]"
+                  className="ml-2 -mr-2 flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-[#10b981]/40 bg-[#10b981]/15 text-[#10b981] shadow-lg shadow-black/30 backdrop-blur-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#181b1f]"
                   aria-label="Avancer"
                   onClick={() => scrollRight(idx)}
                 >
-                  <ChevronRight className="w-6 h-6" aria-hidden="true" />
+                  <ChevronRight className="h-6 w-6" aria-hidden="true" />
                 </button>
               )}
             </div>

--- a/components/sections/Experiences.tsx
+++ b/components/sections/Experiences.tsx
@@ -1,6 +1,5 @@
 import { ChevronRight } from 'lucide-react';
 import { useRef } from 'react';
-import Tag from '../ui/Tag';
 import { experiencesData } from '../../data/experiences';
 import { formatDescription } from '../../lib/experience';
 
@@ -21,7 +20,7 @@ export default function Experiences() {
       <div className="relative max-w-[100vw] px-4" style={{ overflow: 'hidden' }}>
         <div
           ref={scrollRef}
-          className="flex items-stretch gap-4 md:gap-8 pl-8 pr-8 overflow-x-auto snap-x snap-mandatory scrollbar-hide"
+          className="flex items-stretch gap-4 md:gap-8 pl-4 pr-4 sm:pl-8 sm:pr-8 overflow-x-auto snap-x snap-mandatory scrollbar-hide"
           style={{ WebkitOverflowScrolling: 'touch', scrollBehavior: 'smooth' }}
           tabIndex={0}
           role="list"
@@ -30,7 +29,7 @@ export default function Experiences() {
           {experiencesData.map((exp, idx) => (
             <div key={exp.company + idx} className="flex items-center" role="listitem">
               <article
-                className={`exp-card relative pt-6 min-w-[280px] md:min-w-[340px] max-w-xs bg-[#23272a] rounded-2xl shadow-xl p-6 border border-white/10 flex-shrink-0 flex flex-col h-full snap-start`}
+                className={`exp-card relative pt-6 min-w-[280px] md:min-w-[340px] max-w-sm bg-[#23272a] rounded-2xl shadow-xl p-8 md:p-10 border border-white/10 flex-shrink-0 flex flex-col h-full snap-start transition-transform duration-300 hover:scale-[1.02] hover:border-[#10b981]`}
                 aria-labelledby={`experience-${idx}`}
               >
                 {/* 🟢 Badge date dans le coin */}
@@ -54,11 +53,11 @@ export default function Experiences() {
               {idx < experiencesData.length - 1 && (
                 <button
                   type="button"
-                  className="ml-2 p-2 rounded-full hover:bg-[#10b981]/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#23272a] transition"
+                  className="ml-2 flex h-12 w-12 items-center justify-center rounded-full border border-[#10b981]/40 bg-[#10b981]/15 text-[#10b981] shadow-lg shadow-black/30 backdrop-blur-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#181b1f]"
                   aria-label="Avancer"
                   onClick={() => scrollRight(idx)}
                 >
-                  <ChevronRight className="w-7 h-7 text-[#10b981]" aria-hidden="true" />
+                  <ChevronRight className="w-6 h-6" aria-hidden="true" />
                 </button>
               )}
             </div>

--- a/components/sections/Experiences.tsx
+++ b/components/sections/Experiences.tsx
@@ -1,77 +1,56 @@
-import { ChevronRight } from 'lucide-react';
-import { useRef } from 'react';
 import { experiencesData } from '../../data/experiences';
 import { formatDescription } from '../../lib/experience';
 
 export default function Experiences() {
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  const scrollRight = (idx: number) => {
-    if (!scrollRef.current) return;
-
-    const cards = scrollRef.current.querySelectorAll('.exp-card');
-    const card = cards[idx + 1] as HTMLElement | undefined;
-    if (card) {
-      card.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'nearest' });
-    }
-  };
-
   return (
     <section id="experiences" className="py-24 scroll-mt-24" aria-labelledby="experiences-title">
-      <h2 id="experiences-title" className="text-3xl font-extrabold mb-10 text-center text-white tracking-tight">
+      <h2
+        id="experiences-title"
+        className="mb-12 text-center text-3xl font-extrabold tracking-tight text-white sm:text-4xl"
+      >
         Expériences
       </h2>
 
-      <div className="relative max-w-[100vw] px-4">
-        <div
-          ref={scrollRef}
-          className="flex items-stretch gap-4 md:gap-8 pl-4 pr-12 sm:pl-8 sm:pr-16 overflow-x-auto snap-x snap-mandatory scrollbar-hide"
-          style={{ WebkitOverflowScrolling: 'touch', scrollBehavior: 'smooth' }}
-          tabIndex={0}
-          role="list"
-          aria-label="Parcours professionnel"
-        >
-          {experiencesData.map((exp, idx) => (
-            <div key={exp.company + idx} className="flex items-center" role="listitem">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-5 hidden w-px bg-gradient-to-b from-[#10b981] to-transparent sm:block" />
+
+          <div className="space-y-10">
+            {experiencesData.map((exp, idx) => (
               <article
-                className="exp-card relative flex h-full min-w-[280px] max-w-sm flex-shrink-0 flex-col rounded-2xl border border-white/10 bg-[#23272a] p-8 pt-6 shadow-xl transition-transform duration-300 hover:scale-[1.02] hover:border-[#10b981] md:min-w-[340px] md:p-10"
+                key={`${exp.company}-${idx}`}
+                className="relative rounded-3xl border border-white/5 bg-[#1d2125] p-6 pl-12 shadow-[0_15px_40px_-30px_rgba(16,185,129,0.8)] transition hover:border-[#10b981]/40 hover:shadow-[0_25px_50px_-30px_rgba(16,185,129,1)] sm:p-8 sm:pl-20"
                 aria-labelledby={`experience-${idx}`}
               >
-                <div className="absolute right-0 top-0 rounded-bl-2xl rounded-tr-2xl border border-[#10b981]/30 bg-[#10b981]/20 px-3 py-1 text-xs font-semibold text-[#10b981]">
-                  {exp.date}
-                </div>
-
-                <div className="space-y-4">
-                  <header id={`experience-${idx}`} className="space-y-1">
-                    <p className="text-2xl font-extrabold text-white">{exp.company}</p>
-                    <p className="text-[12px] uppercase tracking-[0.12em] text-gray-300">{exp.role}</p>
-                  </header>
-                  <p
-                    className="text-sm leading-relaxed text-gray-200"
-                    dangerouslySetInnerHTML={{ __html: formatDescription(exp.description) }}
-                  />
-                </div>
-              </article>
-
-              {idx < experiencesData.length - 1 && (
-                <button
-                  type="button"
-                  className="ml-2 -mr-2 flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-[#10b981]/40 bg-[#10b981]/15 text-[#10b981] shadow-lg shadow-black/30 backdrop-blur-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#10b981] focus-visible:ring-offset-2 focus-visible:ring-offset-[#181b1f]"
-                  aria-label="Avancer"
-                  onClick={() => scrollRight(idx)}
+                <span
+                  className="absolute left-5 top-10 flex h-6 w-6 -translate-x-1/2 items-center justify-center rounded-full border border-[#10b981]/60 bg-[#10b981]/10 text-[#10b981] shadow-lg sm:left-5"
+                  aria-hidden="true"
                 >
-                  <ChevronRight className="h-6 w-6" aria-hidden="true" />
-                </button>
-              )}
-            </div>
-          ))}
+                  <span className="h-2 w-2 rounded-full bg-[#10b981]" />
+                </span>
+
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p id={`experience-${idx}`} className="text-2xl font-extrabold text-white">
+                      {exp.company}
+                    </p>
+                    <p className="text-xs uppercase tracking-[0.2em] text-gray-400">{exp.role}</p>
+                  </div>
+
+                  <span className="inline-flex w-fit rounded-full border border-[#10b981]/30 bg-[#10b981]/15 px-4 py-1 text-xs font-semibold text-[#10b981]">
+                    {exp.date}
+                  </span>
+                </div>
+
+                <p
+                  className="mt-4 text-base leading-relaxed text-gray-200"
+                  dangerouslySetInnerHTML={{ __html: formatDescription(exp.description) }}
+                />
+              </article>
+            ))}
+          </div>
         </div>
       </div>
-
-      <style jsx global>{`
-        .scrollbar-hide::-webkit-scrollbar { display: none; }
-        .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
-      `}</style>
     </section>
   );
 }

--- a/components/sections/Services.tsx
+++ b/components/sections/Services.tsx
@@ -1,4 +1,5 @@
 import { Compass, Sparkle, Hammer, Users } from 'lucide-react';
+import { cardBaseClasses, sectionTitleGradientClasses } from '../sectionStyles';
 
 const services = [
   {
@@ -26,7 +27,7 @@ const services = [
 export default function Services() {
   return (
     <section id="services" className="py-20 w-full bg-[#181b1f] scroll-mt-24" aria-labelledby="services-title">
-      <h2 id="services-title" className="text-3xl font-extrabold mb-10 text-center text-white tracking-tight">
+      <h2 id="services-title" className={`${sectionTitleGradientClasses} mb-10`}>
         Services
       </h2>
       <ul
@@ -43,7 +44,7 @@ export default function Services() {
           return (
             <li key={service.title} className="flex justify-center w-full">
               <article
-                className="bg-[#23272a] rounded-2xl shadow-xl p-8 md:p-10 border border-white/10 hover:scale-[1.02] hover:shadow-2xl hover:border-[#10b981] transition group flex flex-col items-center text-center focus-within:outline-none w-full max-w-sm"
+                className={`${cardBaseClasses} w-full max-w-sm p-8 md:p-10 flex flex-col items-center text-center`}
                 aria-labelledby={`service-${slug}`}
               >
                 {service.icon}

--- a/components/sections/Services.tsx
+++ b/components/sections/Services.tsx
@@ -29,7 +29,10 @@ export default function Services() {
       <h2 id="services-title" className="text-3xl font-extrabold mb-10 text-center text-white tracking-tight">
         Services
       </h2>
-      <ul className="grid md:grid-cols-4 gap-8 max-w-6xl mx-auto px-4" role="list">
+      <ul
+        className="grid gap-8 sm:gap-10 md:grid-cols-2 xl:grid-cols-4 max-w-5xl w-full mx-auto px-6 md:px-8 justify-items-center"
+        role="list"
+      >
         {services.map((service) => {
           const slug = service.title
             .toLowerCase()
@@ -38,9 +41,9 @@ export default function Services() {
             .replace(/[^a-z0-9]+/g, '-');
 
           return (
-            <li key={service.title} className="flex">
+            <li key={service.title} className="flex justify-center w-full">
               <article
-                className="bg-[#23272a] rounded-2xl shadow-xl p-8 border border-white/10 hover:scale-[1.02] hover:shadow-2xl hover:border-[#10b981] transition group flex flex-col items-center text-center focus-within:outline-none"
+                className="bg-[#23272a] rounded-2xl shadow-xl p-8 md:p-10 border border-white/10 hover:scale-[1.02] hover:shadow-2xl hover:border-[#10b981] transition group flex flex-col items-center text-center focus-within:outline-none w-full max-w-sm"
                 aria-labelledby={`service-${slug}`}
               >
                 {service.icon}


### PR DESCRIPTION
## Summary
- center the services cards on small screens and harmonize padding across breakpoints
- adjust experience cards spacing and enhance the navigation arrow for better visibility on mobile

## Testing
- npm run lint *(fails: command prompts for configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69172f024a28832d9d0eb129d0fb816e)